### PR TITLE
init: Add a "starting" state for services

### DIFF
--- a/init/init.c
+++ b/init/init.c
@@ -256,6 +256,9 @@ void service_start(struct service *svc, const char *dynamic_args)
 
     NOTICE("starting '%s'\n", svc->name);
 
+    if (properties_inited())
+        notify_service_state(svc->name, "starting");
+
     pid = fork();
 
     if (pid == 0) {


### PR DESCRIPTION
 * We might want to trigger something before actually execing the
   service in question in order to do some pre-flight tasks.

 * This lets you do the following:

   on property:init.svc.awesomed=starting
     write /sys/module/awesomemod/parameters/everything_is_awesome 1

   ..and when awesomed starts, it will run this trigger before forking.

Change-Id: I9756b46eafd884d367fe8304b859de2152bdfeb4